### PR TITLE
Fix link in lsp-bridge.nix

### DIFF
--- a/elisp/lsp-bridge.nix
+++ b/elisp/lsp-bridge.nix
@@ -1,4 +1,4 @@
-# Based on https://github.com/akirak/nixpkgs/blob/tree-sitter-mermaid/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lsp-bridge/default.nix
+# Based on https://github.com/akirak/nixpkgs/blob/a790cc526b488cf5d9966e9a45d2f4d2a92963a5/pkgs/applications/editors/emacs/elisp-packages/manual-packages/lsp-bridge/default.nix
 {pkgs, ...}: _old: {
   patches = [
     (pkgs.substituteAll {


### PR DESCRIPTION
Somehow `browse-at-remote` didn't generate a correct URL, so I have copied a proper permalink from the GitHub website.